### PR TITLE
adding taskdef.json file

### DIFF
--- a/taskdef.json
+++ b/taskdef.json
@@ -1,0 +1,24 @@
+{
+    "family": "lendlease-cats", 
+    "networkMode": "awsvpc",
+    "executionRoleArn": "arn:aws:iam::614658524125:role/ecsTaskExecutionRole", 
+    "containerDefinitions": [
+        {
+            "name": "lendlease-cats", 
+            "image": "<IMAGE>", 
+            "portMappings": [
+                {
+                    "containerPort": 80, 
+                    "hostPort": 80, 
+                    "protocol": "tcp"
+                }
+            ], 
+            "essential": true
+        }
+    ], 
+    "requiresCompatibilities": [
+        "FARGATE"
+    ], 
+    "cpu": "256", 
+    "memory": "512"
+}


### PR DESCRIPTION
This file is required for supporting blue-green deployments using ECS.